### PR TITLE
Correctly build settings from validateSettings payload

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -40,19 +40,17 @@ func NewSettingsFromValidationReq(payload []byte) (Settings, error) {
 // Builds a new Settings instance starting from a Settings
 // payload:
 // {
-//  "settings": {
-//     "allowedHostPaths": [
-//     	{
-//     	  "pathPrefix": "foo",
-//     	  "readOnly": true,
-//        }
-//     ]
-//  }
+//   "allowedHostPaths": [
+//   	{
+//   	  "pathPrefix": "foo",
+//   	  "readOnly": true,
+//      }
+//   ]
 // }
 func NewSettingsFromValidateSettingsPayload(payload []byte) (Settings, error) {
 	return newSettings(
 		payload,
-		"settings.allowedHostPaths")
+		"allowedHostPaths")
 }
 
 func newSettings(payload []byte, paths ...string) (Settings, error) {


### PR DESCRIPTION
No changes needed to unit nor e2e tests.